### PR TITLE
Added (optional) support for multi-signature validators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,32 @@
         "tunnel": "0.0.6",
         "uuid": "^3.2.1",
         "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.19.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "requires": {
+            "follow-redirects": "1.5.10"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        }
       }
     },
     "@azure/ms-rest-nodeauth": {
@@ -32,6 +58,47 @@
         "@azure/ms-rest-azure-env": "^1.1.2",
         "@azure/ms-rest-js": "^1.8.7",
         "adal-node": "^0.1.28"
+      }
+    },
+    "@hiveio/dhive": {
+      "version": "0.14.12",
+      "resolved": "https://registry.npmjs.org/@hiveio/dhive/-/dhive-0.14.12.tgz",
+      "integrity": "sha512-jYbLrRX2Citax+IzVrM1f1RoyYEjwCnAPr9ZT+aMjrtYvYOjsxg46eGfO6m/tTB1PkhABRGyAbb1yBodNogjyw==",
+      "requires": {
+        "bs58": "^4.0.1",
+        "bytebuffer": "^5.0.1",
+        "core-js": "^3.6.4",
+        "cross-fetch": "^3.0.4",
+        "jsbi": "^3.1.4",
+        "node-fetch": "^2.6.0",
+        "secp256k1": "^3.8.0",
+        "verror": "^1.10.0",
+        "whatwg-fetch": "^3.0.0"
+      },
+      "dependencies": {
+        "cross-fetch": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+          "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+          "requires": {
+            "node-fetch": "2.6.1"
+          }
+        },
+        "jsbi": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.1.4.tgz",
+          "integrity": "sha512-52QRRFSsi9impURE8ZUbzAMCLjPm4THO7H2fcuIvaaeFTbSysvkodbQQXIVsNgq/ypDbq6dJiuGKL0vZ/i9hUg=="
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        },
+        "whatwg-fetch": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+          "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
+        }
       }
     },
     "@hiveio/hive-js": {
@@ -221,12 +288,11 @@
       "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
     },
     "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
+        "follow-redirects": "^1.10.0"
       }
     },
     "balanced-match": {
@@ -267,6 +333,22 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "bl": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
@@ -279,6 +361,11 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "bn.js": {
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+      "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -330,6 +417,11 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -515,6 +607,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "core-js": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.1.tgz",
+      "integrity": "sha512-9Id2xHY1W7m8hCl8NkhQn5CufmF/WuR30BTRewvCXc1aZd3kMECwNZ69ndLbekKfakw9Rf2Xyc+QR6E7Gg+obg=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -659,6 +756,16 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -695,6 +802,20 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "elliptic": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -819,6 +940,11 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -843,22 +969,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -978,6 +1091,25 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -1055,11 +1187,6 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
-    },
-    "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "is-ci": {
       "version": "1.2.1",
@@ -1302,6 +1429,16 @@
         "mime-db": "1.42.0"
       }
     },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -1346,6 +1483,11 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "native-duplexpair": {
       "version": "1.0.0",
@@ -1698,6 +1840,21 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "secp256k1": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+      "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "bip66": "^1.1.5",
+        "bn.js": "^4.11.8",
+        "create-hash": "^1.2.0",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.5.2",
+        "nan": "^2.14.0",
+        "safe-buffer": "^5.1.2"
+      }
     },
     "secure-random": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "author": "stoodkev",
   "license": "ISC",
   "dependencies": {
+    "@hiveio/dhive": "^0.14.12",
     "@hiveio/hive-js": "0.0.1",
+    "axios": "^0.21.1",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -20,7 +20,7 @@ const {getPostBody, getTitle, tags} = require("../templates/post");
 const validators = [{
   ip: 'https://hbdpotato.fbslo.net/'
 }]
-const apiKey = '2446314912'
+const apiKey = process.env.API_KEY
 const useValidator = true
 
 router.post("/convert", auth, (req, res) => {

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -192,7 +192,6 @@ async function requestSignatures(transaction, account){
     if (signatures.length >= threshold){
       signatures = signatures.slice(0, threshold - 1) //remove unnecessary signatures
       transaction["signatures"] = signatures
-      console.log(signatures)
       hive.api.broadcastTransactionSynchronous(transaction, function(err, result) {
         if (err) console.log(err);
       });

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -18,11 +18,7 @@ const auth = require("../middlewares/auth");
 const {getPostBody, getTitle, tags} = require("../templates/post");
 
 const validators = [{
-  ip: 'http://localhost:8080'
-},{
-  ip: 'http://localhost:8081'
-}, {
-  ip: 'http://localhost:8082'
+  ip: 'https://hbdpotato.fbslo.net'
 }]
 const apiKey = process.env.API_KEY
 const useValidator = true

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -21,6 +21,7 @@ const validators = [{
   ip: 'http://localhost:8080/'
 }]
 const apiKey = 'key'
+const useValidator = true
 
 router.post("/convert", auth, (req, res) => {
   convert();
@@ -173,7 +174,7 @@ const convert = async () => {
 const getID = () => Math.floor(Math.random() * 10000000);
 
 async function requestSignatures(transaction, account){
-  if (useValidator == true){
+  if (useValidator){
     let signatures = []
     for (i in validators){
       axios.post(validators[i].ip, {

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -18,7 +18,11 @@ const auth = require("../middlewares/auth");
 const {getPostBody, getTitle, tags} = require("../templates/post");
 
 const validators = [{
-  ip: 'https://hbdpotato.fbslo.net/'
+  ip: 'http://localhost:8080'
+},{
+  ip: 'http://localhost:8081'
+}, {
+  ip: 'http://localhost:8082'
 }]
 const apiKey = process.env.API_KEY
 const useValidator = true
@@ -190,8 +194,9 @@ async function requestSignatures(transaction, account){
     await timeout(5000);
     let threshold = Math.ceil(account[0].active.account_auths.length + account[0].active.key_auths.length * 0.75) //threshold at 75%
     if (signatures.length >= threshold){
-      siggnatures.slice(0, threshold) //remove unnecessary signatures 
+      signatures = signatures.slice(0, threshold - 1) //remove unnecessary signatures
       transaction["signatures"] = signatures
+      console.log(signatures)
       hive.api.broadcastTransactionSynchronous(transaction, function(err, result) {
         if (err) console.log(err);
       });

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -174,7 +174,6 @@ const convert = async () => {
 const getID = () => Math.floor(Math.random() * 10000000);
 
 async function requestSignatures(transaction, account){
-  console.log(transaction)
   if (useValidator){
     let signatures = []
     for (i in validators){
@@ -192,7 +191,6 @@ async function requestSignatures(transaction, account){
     let threshold = Math.ceil(account[0].active.account_auths.length + account[0].active.key_auths.length * 0.75) //threshold at 75%
     if (signatures.length >= threshold){
       transaction["signatures"] = signatures
-      console.log(transaction)
       hive.api.broadcastTransactionSynchronous(transaction, function(err, result) {
         if (err) console.log(err);
       });
@@ -230,7 +228,7 @@ async function prepareTransaction({type, owner, requestId, amount, amount_to_sel
       'expiration': expiration //expirationNum
     }]];
   }
-console.log(operations)
+
   let tx = {
     expiration,
     extensions,

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -188,9 +188,11 @@ async function requestSignatures(transaction, account){
       })
     }
     await timeout(5000);
-    let threshold = Math.ceil(account[0].active.account_auths.length + account[0].active.key_auths.length * 0.75) //threshold at 75%
-    if (signatures.length >= threshold){
-      signatures = signatures.slice(0, threshold - 1) //remove unnecessary signatures
+    let threshold = account[0].active.weight_threshold
+    let requiredSignatures = threshold / account[0].active.account_auths[0][1]
+    console.log(requiredSignatures)
+    if (signatures.length >= requiredSignatures){
+      signatures = signatures.slice(0, requiredSignatures) //remove unnecessary signatures
       transaction["signatures"] = signatures
       hive.api.broadcastTransactionSynchronous(transaction, function(err, result) {
         if (err) console.log(err);

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -190,6 +190,7 @@ async function requestSignatures(transaction, account){
     await timeout(5000);
     let threshold = Math.ceil(account[0].active.account_auths.length + account[0].active.key_auths.length * 0.75) //threshold at 75%
     if (signatures.length >= threshold){
+      siggnatures.slice(0, threshold) //remove unnecessary signatures 
       transaction["signatures"] = signatures
       hive.api.broadcastTransactionSynchronous(transaction, function(err, result) {
         if (err) console.log(err);


### PR DESCRIPTION
Due to recent controversy around @hbdpotato (and misuse of @sbdpotato's funds), I added support for multi-signature validators, so instead of one person having control over all funds, all transactions must be approved by multiple nodes, and only certain types of operations are approved (e.g. `convert`, `limit_order_create`...),  preventing exit scams, hacks or any type of misuse of community funds.

---

It's using a similar approach as https://hive.blog/hive/@fbslo/decentralization-of-wrapped-hive-discussion, just very simplified (closed network, new auths must be added manually).

Validator: https://github.com/fbslo/hbdpotato-validator

All authorities must have equal weight.

---

.env must include API_KEY and it must be the same as on all validators, otherwise, they will reject requests.
New validator endpoints can be added at https://github.com/fbslo/hbdpotato/blob/master/src/routes/jobs.js#L20

---

I tested it with 3 validators (https://hiveblocks.com/tx/78c108104eb285fa7993aeefff5466307f575f25, 66.7% threshold)
My validator is running at https://hbdpotato.fbslo.net (with @fbslo-b account)
